### PR TITLE
Remove unnecessary flex and class around main view.

### DIFF
--- a/src/SampleWebsiteTheme/wwwroot/SampleWebsiteTheme/html/DesktopSurface.html
+++ b/src/SampleWebsiteTheme/wwwroot/SampleWebsiteTheme/html/DesktopSurface.html
@@ -132,7 +132,6 @@
                 align-items: center;
             }
 
-
             .desktop-theme__top-right ::content > starcounter-include > juicy-composition > *,
             .desktop-theme__top-right ::content > starcounter-include > juicy-composition starcounter-include > juicy-composition > *,
             /*
@@ -161,13 +160,7 @@
                 padding: 0;
             }
 
-            .desktop-theme__content {
-                display: flex;
-                flex: 1 1 auto;
-            }
-
             .desktop-theme__main {
-                flex: 1 0 auto;
                 background: var(--primary-background, white);
                 color: var(--primary-color, black);
             }
@@ -258,11 +251,9 @@
             <div class="desktop-theme__menu">
                 <slot name="samplewebsitetheme/mainmenu"></slot>
             </div>
-            <div class="desktop-theme__content">
-                <div class="desktop-theme__main">
-                    <div class="desktop-theme__padded">
-                        <slot name="samplewebsitetheme/main"></slot>
-                    </div>
+            <div class="desktop-theme__main">
+                <div class="desktop-theme__padded">
+                    <slot name="samplewebsitetheme/main"></slot>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
### Steps to reproduce 
1. Build and run develop versions of: Website (with WebsiteProvider), SampleWebsiteTheme, SignIn and Calendar.
2. Go to Calendar page.

### Current behaviour
Calendar is stretched into enormous size (something around 100000x100000px).

### Behaviour after fix
Calendar renders properly.

### Description
Using flex on main element causes issue with Calendar app, where entire body of application is stretched to enormous size. Is that flex usage necessary? If not I suggest to remove it because It can cause more issues in the future.

@tomalec @joozek78 tell me what do You think?