### PR TITLE
Pass along parameters to star (run.bat)

### DIFF
--- a/run.bat
+++ b/run.bat
@@ -2,4 +2,4 @@
 
 IF "%CONFIGURATION%"=="" SET CONFIGURATION=Debug
 
-star --resourcedir="%~dp0src\SampleWebsiteTheme\wwwroot" "%~dp0src\SampleWebsiteTheme\bin\%CONFIGURATION%\SampleWebsiteTheme.exe"
+star %* --resourcedir="%~dp0src\SampleWebsiteTheme\wwwroot" "%~dp0src\SampleWebsiteTheme\bin\%CONFIGURATION%\SampleWebsiteTheme.exe"


### PR DESCRIPTION
Pass along parameters to star (run.bat); for Starcounter/Guidelines#31 .