### PR TITLE
Fix CSS

### DIFF
--- a/src/SampleWebsiteTheme/wwwroot/SampleWebsiteTheme/html/DesktopSurface.html
+++ b/src/SampleWebsiteTheme/wwwroot/SampleWebsiteTheme/html/DesktopSurface.html
@@ -22,6 +22,10 @@
         .desktop-theme__top-right-slotted a {
             color: var(--secondary-color, whitesmoke);
         }
+        
+        .desktop-theme__top-right-slotted > * {
+            margin-right: 5px;
+        }
 
         .desktop-theme__top-right-slotted paper-icon-button {
             width: 100%;
@@ -144,16 +148,6 @@
             .desktop-theme__top-right > starcounter-include {
                 display: flex;
                 align-items: center;
-            }
-
-            .desktop-theme__top-right ::slotted(starcounter-include) {
-                margin-right: 5px;
-            }
-
-            /** duplicated rule for polyfilled browsers */
-
-            .desktop-theme__top-right > starcounter-include {
-                margin-right: 5px;
             }
 
             .desktop-theme__main {

--- a/src/SampleWebsiteTheme/wwwroot/SampleWebsiteTheme/html/DesktopSurface.html
+++ b/src/SampleWebsiteTheme/wwwroot/SampleWebsiteTheme/html/DesktopSurface.html
@@ -23,26 +23,6 @@
             color: var(--secondary-color, whitesmoke);
         }
 
-        .desktop-theme__top-center-slotted > juicy-composition,
-        .desktop-theme__top-center-slotted > juicy-composition > starcounter-include > juicy-composition {
-            display: flex;
-            align-items: center;
-            justify-content: flex-end;
-        }
-
-        .desktop-theme__top-leftmost-slotted > juicy-composition,
-        .desktop-theme__top-leftmost-slotted > juicy-composition > starcounter-include > juicy-composition,
-        .desktop-theme__top-right-slotted > juicy-composition,
-        .desktop-theme__top-right-slotted > juicy-composition > starcounter-include > juicy-composition {
-            display: flex;
-            align-items: center;
-        }
-
-        .desktop-theme__top-right-slotted > juicy-composition > *,
-        .desktop-theme__top-right-slotted > juicy-composition starcounter-include > juicy-composition > * {
-            margin-right: 5px;
-        }
-
         .desktop-theme__top-right-slotted paper-icon-button {
             width: 100%;
             height: 100%;
@@ -136,6 +116,44 @@
             .desktop-theme__top-right {
                 display: flex;
                 align-items: center;
+            }
+
+            .desktop-theme__top-center ::slotted(starcounter-include) {
+                display: flex;
+                align-items: center;
+                justify-content: flex-end;
+            }
+                        
+            /** duplicated rule for polyfilled browsers */
+
+            .desktop-theme__top-center > starcounter-include {
+                display: flex;
+                align-items: center;
+                justify-content: flex-end;
+            }
+
+            .desktop-theme__top-leftmost ::slotted(i),
+            .desktop-theme__top-right ::slotted(starcounter-include) {
+                display: flex;
+                align-items: center;
+            }
+
+            /** duplicated rule for polyfilled browsers */
+
+            .desktop-theme__top-leftmost > i,
+            .desktop-theme__top-right > starcounter-include {
+                display: flex;
+                align-items: center;
+            }
+
+            .desktop-theme__top-right ::slotted(starcounter-include) {
+                margin-right: 5px;
+            }
+
+            /** duplicated rule for polyfilled browsers */
+
+            .desktop-theme__top-right > starcounter-include {
+                margin-right: 5px;
             }
 
             .desktop-theme__main {

--- a/src/SampleWebsiteTheme/wwwroot/SampleWebsiteTheme/html/DesktopSurface.html
+++ b/src/SampleWebsiteTheme/wwwroot/SampleWebsiteTheme/html/DesktopSurface.html
@@ -32,6 +32,12 @@
             height: 100%;
             padding: 0;
         }
+
+        .desktop-theme__top-center ::slotted(starcounter-include) {
+            display: flex;
+            align-items: center;
+            justify-content: flex-end;   
+        }
     </style>
     <template is="dom-bind">
         <i slot="samplewebsitetheme/menu-button" class="glyphicon glyphicon-menu-hamburger desktop-theme-button__icon desktop-theme__top-leftmost" on-click="toggleMenu"></i>

--- a/src/SampleWebsiteTheme/wwwroot/SampleWebsiteTheme/html/DesktopSurface.html
+++ b/src/SampleWebsiteTheme/wwwroot/SampleWebsiteTheme/html/DesktopSurface.html
@@ -43,10 +43,9 @@
             margin-right: 5px;
         }
 
-        .desktop-theme__top-right-slotted svg,
         .desktop-theme__top-right-slotted paper-icon-button {
-            width: 24px;
-            height: 24px;
+            width: 100%;
+            height: 100%;
             padding: 0;
         }
     </style>

--- a/src/SampleWebsiteTheme/wwwroot/SampleWebsiteTheme/html/DesktopSurface.html
+++ b/src/SampleWebsiteTheme/wwwroot/SampleWebsiteTheme/html/DesktopSurface.html
@@ -38,6 +38,12 @@
             align-items: center;
             justify-content: flex-end;   
         }
+
+        .desktop-theme__top-center > starcounter-include {
+            display: flex;
+            align-items: center;
+            justify-content: flex-end;   
+        }
     </style>
     <template is="dom-bind">
         <i slot="samplewebsitetheme/menu-button" class="glyphicon glyphicon-menu-hamburger desktop-theme-button__icon desktop-theme__top-leftmost" on-click="toggleMenu"></i>

--- a/src/SampleWebsiteTheme/wwwroot/SampleWebsiteTheme/html/DesktopSurface.html
+++ b/src/SampleWebsiteTheme/wwwroot/SampleWebsiteTheme/html/DesktopSurface.html
@@ -16,19 +16,39 @@
             cursor: pointer;
         }
 
-        .desktop-theme__top-center > juicy-composition,
-        .desktop-theme__top-center > juicy-composition > starcounter-include > juicy-composition {
+        .desktop-theme__top-center-slotted > juicy-composition,
+        .desktop-theme__top-center-slotted > juicy-composition > starcounter-include > juicy-composition {
             display: flex;
             align-items: center;
             justify-content: flex-end;
         }
+
+        .desktop-theme__top-leftmost-slotted > juicy-composition,
+        .desktop-theme__top-leftmost-slotted > juicy-composition > starcounter-include > juicy-composition,
+        .desktop-theme__top-right-slotted > juicy-composition,
+        .desktop-theme__top-right-slotted > juicy-composition > starcounter-include > juicy-composition {
+            display: flex;
+            align-items: center;
+        }
+
+        .desktop-theme__top-right-slotted > juicy-composition > *,
+        .desktop-theme__top-right-slotted > juicy-composition starcounter-include > juicy-composition > * {
+            margin-right: 5px;
+        }
+
+        .desktop-theme__top-right-slotted svg,
+        .desktop-theme__top-right-slotted paper-icon-button {
+            width: 24px;
+            height: 24px;
+            padding: 0;
+        }
     </style>
     <template is="dom-bind">
-        <i slot="samplewebsitetheme/menu-button" class="glyphicon glyphicon-menu-hamburger desktop-theme-button__icon" on-click="toggleMenu"></i>
+        <i slot="samplewebsitetheme/menu-button" class="glyphicon glyphicon-menu-hamburger desktop-theme-button__icon desktop-theme__top-leftmost-slotted" on-click="toggleMenu"></i>
         <starcounter-include slot="samplewebsitetheme/topbar-leftcorner" partial="{{model.Sections.TopBarLeftCorner}}" is-visible$="[[_showMainMenu]]" on-click="toggleMenu"></starcounter-include>
         <starcounter-include slot="samplewebsitetheme/topbar-left" partial="{{model.Sections.TopBarLeft}}"></starcounter-include>
-        <starcounter-include slot="samplewebsitetheme/topbar-center" partial="{{model.Sections.TopBarCenter}}" class="desktop-theme__top-center"></starcounter-include>
-        <starcounter-include slot="samplewebsitetheme/topbar-right" partial="{{model.Sections.TopBarRight}}"></starcounter-include>
+        <starcounter-include slot="samplewebsitetheme/topbar-center" partial="{{model.Sections.TopBarCenter}}" class="desktop-theme__top-center-slotted"></starcounter-include>
+        <starcounter-include slot="samplewebsitetheme/topbar-right" class="desktop-theme__top-right-slotted" partial="{{model.Sections.TopBarRight}}"></starcounter-include>
         <starcounter-include slot="samplewebsitetheme/main" partial="{{model.Sections.Main}}"></starcounter-include>
     </template>
     <script>
@@ -120,51 +140,6 @@
             .desktop-theme__top-right {
                 display: flex;
                 align-items: center;
-            }
-
-
-            .desktop-theme__top-leftmost ::slotted(starcounter-include > juicy-composition),
-            .desktop-theme__top-leftmost ::slotted(starcounter-include > juicy-composition > starcounter-include > juicy-composition),
-            .desktop-theme__top-right ::slotted(starcounter-include > juicy-composition),
-            .desktop-theme__top-right ::slotted(starcounter-include > juicy-composition > starcounter-include > juicy-composition) {
-                display: flex;
-                align-items: center;
-            }
-            /** duplicated rule for polyfilled browsers */
-            .desktop-theme__top-leftmost > starcounter-include > juicy-composition,
-            .desktop-theme__top-leftmost > starcounter-include > juicy-composition > starcounter-include > juicy-composition,
-            .desktop-theme__top-right > starcounter-include > juicy-composition,
-            .desktop-theme__top-right > starcounter-include > juicy-composition > starcounter-include > juicy-composition {
-                display: flex;
-                align-items: center;
-            }
-
-            .desktop-theme__top-right ::slotted(starcounter-include > juicy-composition > *),
-            .desktop-theme__top-right ::slotted(starcounter-include > juicy-composition starcounter-include > juicy-composition > *),
-            /*
-                Shadow DOM v1 in-compatible Shadow DOM piercing selector
-                styling such things may break default compositions delivered by apps
-            */
-            .desktop-theme__top-right ::slotted(starcounter-include > juicy-composition::shadow > *),
-            .desktop-theme__top-right ::slotted(starcounter-include > juicy-composition > starcounter-include > juicy-composition::shadow > *) {
-                margin-right: 5px;
-            }
-            /** duplicated rule for polyfilled browsers */
-            .desktop-theme__top-right > starcounter-include > juicy-composition > *,
-            .desktop-theme__top-right > starcounter-include > juicy-composition starcounter-include > juicy-composition > * {
-                margin-right: 5px;
-            }
-
-            .desktop-theme__top-right ::slotted(paper-icon-button) {
-                width: 24px;
-                height: 24px;
-                padding: 0;
-            }
-            /** duplicated rule for polyfilled browsers */
-            .desktop-theme__top-right paper-icon-button {
-                width: 24px;
-                height: 24px;
-                padding: 0;
             }
 
             .desktop-theme__main {

--- a/src/SampleWebsiteTheme/wwwroot/SampleWebsiteTheme/html/DesktopSurface.html
+++ b/src/SampleWebsiteTheme/wwwroot/SampleWebsiteTheme/html/DesktopSurface.html
@@ -2,7 +2,7 @@
 <link rel="import" href="/sys/polymer/polymer.html" />
 
 <template>
-    <style slot="samplewebsitetheme/global-style" shim-shadowdom>
+    <style slot="samplewebsitetheme/global-style">
         html,
         body {
             font-family: "Helvetica", "Arial", sans-serif;
@@ -15,7 +15,14 @@
         .desktop-theme-button__icon {
             cursor: pointer;
         }
-        
+
+        .desktop-theme__top-leftmost a,
+        .desktop-theme__top-left a,
+        .desktop-theme__top-center a,
+        .desktop-theme__top-right a {
+            color: var(--secondary-color, #2196f3);
+        }
+
         .desktop-theme__top-right > * {
             margin-right: 5px;
         }
@@ -26,16 +33,11 @@
             padding: 0;
         }
 
+        polyfill-next-selector { content: '.desktop-theme__top-center > starcounter-include'; }/* for polyfilled browsers*/
         .desktop-theme__top-center ::slotted(starcounter-include) {
             display: flex;
             align-items: center;
-            justify-content: flex-end;   
-        }
-
-        .desktop-theme__top-center > starcounter-include {
-            display: flex;
-            align-items: center;
-            justify-content: flex-end;   
+            justify-content: flex-end;
         }
     </style>
     <template is="dom-bind">
@@ -127,30 +129,16 @@
                 align-items: center;
             }
 
+            polyfill-next-selector { content: '.desktop-theme__top-center > starcounter-include'; }/* for polyfilled browsers*/
             .desktop-theme__top-center ::slotted(starcounter-include) {
                 display: flex;
                 align-items: center;
                 justify-content: flex-end;
             }
-                        
-            /** duplicated rule for polyfilled browsers */
 
-            .desktop-theme__top-center > starcounter-include {
-                display: flex;
-                align-items: center;
-                justify-content: flex-end;
-            }
-
+            polyfill-next-selector { content: '.desktop-theme__top-leftmost > i, .desktop-theme__top-right > starcounter-include'; }/* for polyfilled browsers*/
             .desktop-theme__top-leftmost ::slotted(i),
             .desktop-theme__top-right ::slotted(starcounter-include) {
-                display: flex;
-                align-items: center;
-            }
-
-            /** duplicated rule for polyfilled browsers */
-
-            .desktop-theme__top-leftmost > i,
-            .desktop-theme__top-right > starcounter-include {
                 display: flex;
                 align-items: center;
             }
@@ -164,6 +152,7 @@
                 padding: 20px;
             }
 
+            polyfill-next-selector { content: '.desktop-theme__menu > *'; }/* for polyfilled browsers*/
             .desktop-theme__menu ::slotted(*) {
               width: 100%;
               height: auto;
@@ -190,67 +179,36 @@
               padding: 25px;
             }
 
-            /** duplicated rule for polyfilled browsers */
-            .desktop-theme__menu > * {
-              width: 100%;
-              height: auto;
-              transform: translateX(-150%);
-              background: #333;
-              color: aliceblue;
-              margin-top: 64px;
-              max-height: 100%;
-              position: absolute;
-              top: 0;
-              left: 0;
-              bottom: 0;
-              box-shadow: 0 2px 2px 0 rgba(0,0,0,.14), 0 3px 1px -2px rgba(0,0,0,.2), 0 1px 5px 0 rgba(0,0,0,.12);
-              box-sizing: border-box;
-              border-right: 1px solid #e0e0e0;
-              transform-style: preserve-3d;
-              will-change: transform;
-              transition-duration: .2s;
-              transition-timing-function: cubic-bezier(.4,0,.2,1);
-              transition-property: transform;
-              overflow: visible;
-              overflow-y: auto;
-              z-index: 5;
-              padding: 25px;
-            }
-
+            polyfill-next-selector { content: '.desktop-theme__menu > [is-visible]'; }/* for polyfilled browsers*/
             .desktop-theme__menu ::slotted([is-visible]) {
               transform: translateX(0);
             }
-
-            /** duplicated rule for polyfilled browsers */
-            .desktop-theme__menu > [is-visible] {
-              transform: translateX(0);
-            }
         </style>
-        <div class="desktop-theme">
-            <div class="desktop-theme__top">
-                <div class="desktop-theme__top-leftmost">
-                    <slot name="samplewebsitetheme/menu-button"></slot>
-                </div>
-                <div class="desktop-theme__top-main">
-                    <div class="desktop-theme__top-left">
-                        <slot name="samplewebsitetheme/topbar-left"></slot>
-                    </div>
-                    <div class="desktop-theme__top-center">
-                        <slot name="samplewebsitetheme/topbar-center"></slot>
-                    </div>
-                    <div class="desktop-theme__top-right">
-                        <slot name="samplewebsitetheme/topbar-right"></slot>
-                    </div>
-                </div>
+    <div class="desktop-theme">
+        <div class="desktop-theme__top">
+            <div class="desktop-theme__top-leftmost">
+                <slot name="samplewebsitetheme/menu-button"></slot>
             </div>
-            <div class="desktop-theme__menu">
-                <slot name="samplewebsitetheme/topbar-leftcorner"></slot>
-            </div>
-            <div class="desktop-theme__main">
-                <div class="desktop-theme__padded">
-                    <slot name="samplewebsitetheme/main"></slot>
+            <div class="desktop-theme__top-main">
+                <div class="desktop-theme__top-left">
+                    <slot name="samplewebsitetheme/topbar-left"></slot>
+                </div>
+                <div class="desktop-theme__top-center">
+                    <slot name="samplewebsitetheme/topbar-center"></slot>
+                </div>
+                <div class="desktop-theme__top-right">
+                    <slot name="samplewebsitetheme/topbar-right"></slot>
                 </div>
             </div>
         </div>
+        <div class="desktop-theme__menu">
+            <slot name="samplewebsitetheme/topbar-leftcorner"></slot>
+        </div>
+        <div class="desktop-theme__main">
+            <div class="desktop-theme__padded">
+                <slot name="samplewebsitetheme/main"></slot>
+            </div>
+        </div>
+    </div>
     </template>
 </template>

--- a/src/SampleWebsiteTheme/wwwroot/SampleWebsiteTheme/html/DesktopSurface.html
+++ b/src/SampleWebsiteTheme/wwwroot/SampleWebsiteTheme/html/DesktopSurface.html
@@ -52,8 +52,8 @@
     </style>
     <template is="dom-bind">
         <i slot="samplewebsitetheme/menu-button" class="glyphicon glyphicon-menu-hamburger desktop-theme-button__icon desktop-theme__top-leftmost-slotted" on-click="toggleMenu"></i>
-        <starcounter-include slot="samplewebsitetheme/topbar-leftcorner" class="desktop-theme__top-left-slotted" partial="{{model.Sections.TopBarLeftCorner}}" is-visible$="[[_showMainMenu]]" on-click="toggleMenu"></starcounter-include>
-        <starcounter-include slot="samplewebsitetheme/topbar-left" partial="{{model.Sections.TopBarLeft}}"></starcounter-include>
+        <starcounter-include slot="samplewebsitetheme/topbar-leftcorner" partial="{{model.Sections.TopBarLeftCorner}}" is-visible$="[[_showMainMenu]]" on-click="toggleMenu"></starcounter-include>
+        <starcounter-include slot="samplewebsitetheme/topbar-left" class="desktop-theme__top-left-slotted" partial="{{model.Sections.TopBarLeft}}"></starcounter-include>
         <starcounter-include slot="samplewebsitetheme/topbar-center" partial="{{model.Sections.TopBarCenter}}" class="desktop-theme__top-center-slotted"></starcounter-include>
         <starcounter-include slot="samplewebsitetheme/topbar-right" class="desktop-theme__top-right-slotted" partial="{{model.Sections.TopBarRight}}"></starcounter-include>
         <starcounter-include slot="samplewebsitetheme/main" partial="{{model.Sections.Main}}"></starcounter-include>

--- a/src/SampleWebsiteTheme/wwwroot/SampleWebsiteTheme/html/DesktopSurface.html
+++ b/src/SampleWebsiteTheme/wwwroot/SampleWebsiteTheme/html/DesktopSurface.html
@@ -16,29 +16,29 @@
             cursor: pointer;
         }
 
-        .desktop-theme__top-leftmost-slotted a,
-        .desktop-theme__top-left-slotted a,
-        .desktop-theme__top-center-slotted a,
-        .desktop-theme__top-right-slotted a {
+        .desktop-theme__top-leftmost a,
+        .desktop-theme__top-left a,
+        .desktop-theme__top-center a,
+        .desktop-theme__top-right a {
             color: var(--secondary-color, whitesmoke);
         }
         
-        .desktop-theme__top-right-slotted > * {
+        .desktop-theme__top-right > * {
             margin-right: 5px;
         }
 
-        .desktop-theme__top-right-slotted paper-icon-button {
+        .desktop-theme__top-right paper-icon-button {
             width: 100%;
             height: 100%;
             padding: 0;
         }
     </style>
     <template is="dom-bind">
-        <i slot="samplewebsitetheme/menu-button" class="glyphicon glyphicon-menu-hamburger desktop-theme-button__icon desktop-theme__top-leftmost-slotted" on-click="toggleMenu"></i>
+        <i slot="samplewebsitetheme/menu-button" class="glyphicon glyphicon-menu-hamburger desktop-theme-button__icon desktop-theme__top-leftmost" on-click="toggleMenu"></i>
         <starcounter-include slot="samplewebsitetheme/topbar-leftcorner" partial="{{model.Sections.TopBarLeftCorner}}" is-visible$="[[_showMainMenu]]" on-click="toggleMenu"></starcounter-include>
-        <starcounter-include slot="samplewebsitetheme/topbar-left" class="desktop-theme__top-left-slotted" partial="{{model.Sections.TopBarLeft}}"></starcounter-include>
-        <starcounter-include slot="samplewebsitetheme/topbar-center" partial="{{model.Sections.TopBarCenter}}" class="desktop-theme__top-center-slotted"></starcounter-include>
-        <starcounter-include slot="samplewebsitetheme/topbar-right" class="desktop-theme__top-right-slotted" partial="{{model.Sections.TopBarRight}}"></starcounter-include>
+        <starcounter-include slot="samplewebsitetheme/topbar-left" class="desktop-theme__top-left" partial="{{model.Sections.TopBarLeft}}"></starcounter-include>
+        <starcounter-include slot="samplewebsitetheme/topbar-center" partial="{{model.Sections.TopBarCenter}}" class="desktop-theme__top-center"></starcounter-include>
+        <starcounter-include slot="samplewebsitetheme/topbar-right" class="desktop-theme__top-right" partial="{{model.Sections.TopBarRight}}"></starcounter-include>
         <starcounter-include slot="samplewebsitetheme/main" partial="{{model.Sections.Main}}"></starcounter-include>
     </template>
     <script>

--- a/src/SampleWebsiteTheme/wwwroot/SampleWebsiteTheme/html/DesktopSurface.html
+++ b/src/SampleWebsiteTheme/wwwroot/SampleWebsiteTheme/html/DesktopSurface.html
@@ -15,13 +15,6 @@
         .desktop-theme-button__icon {
             cursor: pointer;
         }
-
-        .desktop-theme__top-leftmost a,
-        .desktop-theme__top-left a,
-        .desktop-theme__top-center a,
-        .desktop-theme__top-right a {
-            color: var(--secondary-color, whitesmoke);
-        }
         
         .desktop-theme__top-right > * {
             margin-right: 5px;

--- a/src/SampleWebsiteTheme/wwwroot/SampleWebsiteTheme/html/DesktopSurface.html
+++ b/src/SampleWebsiteTheme/wwwroot/SampleWebsiteTheme/html/DesktopSurface.html
@@ -16,6 +16,13 @@
             cursor: pointer;
         }
 
+        .desktop-theme__top-leftmost-slotted a,
+        .desktop-theme__top-left-slotted a,
+        .desktop-theme__top-center-slotted a,
+        .desktop-theme__top-right-slotted a {
+            color: var(--secondary-color, whitesmoke);
+        }
+
         .desktop-theme__top-center-slotted > juicy-composition,
         .desktop-theme__top-center-slotted > juicy-composition > starcounter-include > juicy-composition {
             display: flex;
@@ -45,7 +52,7 @@
     </style>
     <template is="dom-bind">
         <i slot="samplewebsitetheme/menu-button" class="glyphicon glyphicon-menu-hamburger desktop-theme-button__icon desktop-theme__top-leftmost-slotted" on-click="toggleMenu"></i>
-        <starcounter-include slot="samplewebsitetheme/topbar-leftcorner" partial="{{model.Sections.TopBarLeftCorner}}" is-visible$="[[_showMainMenu]]" on-click="toggleMenu"></starcounter-include>
+        <starcounter-include slot="samplewebsitetheme/topbar-leftcorner" class="desktop-theme__top-left-slotted" partial="{{model.Sections.TopBarLeftCorner}}" is-visible$="[[_showMainMenu]]" on-click="toggleMenu"></starcounter-include>
         <starcounter-include slot="samplewebsitetheme/topbar-left" partial="{{model.Sections.TopBarLeft}}"></starcounter-include>
         <starcounter-include slot="samplewebsitetheme/topbar-center" partial="{{model.Sections.TopBarCenter}}" class="desktop-theme__top-center-slotted"></starcounter-include>
         <starcounter-include slot="samplewebsitetheme/topbar-right" class="desktop-theme__top-right-slotted" partial="{{model.Sections.TopBarRight}}"></starcounter-include>
@@ -122,16 +129,6 @@
 
             .desktop-theme__top-center {
                 flex: 0 0 auto;
-            }
-
-
-            .desktop-theme__top ::slotted(a) {
-                color: var(--secondary-color, whitesmoke);
-            }
-
-            /** duplicated rule for polyfilled browsers */
-            .desktop-theme__top a {
-                color: var(--secondary-color, whitesmoke);
             }
 
             .desktop-theme__top-leftmost,

--- a/src/SampleWebsiteTheme/wwwroot/SampleWebsiteTheme/html/LoginSurface.html
+++ b/src/SampleWebsiteTheme/wwwroot/SampleWebsiteTheme/html/LoginSurface.html
@@ -2,7 +2,7 @@
 <link rel="import" href="/sys/polymer/polymer.html" />
 
 <template>
-    <style slot="samplewebsitetheme/global-style" shim-shadowdom>
+    <style slot="samplewebsitetheme/global-style">
         body {
             display: flex;
             justify-content: center;
@@ -27,13 +27,6 @@
                 align-items: center;
                 color: #eae9e5;
             }
-
-            .login-theme__logo { margin: auto; }
-
-            .login-theme__logo img { width: 50%; }
-
-            .login-theme__logo span { font-size: 1.2em; }
-   
         </style>
         <div class="login-theme">
             <div class="login-theme__logo">

--- a/src/SampleWebsiteTheme/wwwroot/SampleWebsiteTheme/html/SignInComposition.html
+++ b/src/SampleWebsiteTheme/wwwroot/SampleWebsiteTheme/html/SignInComposition.html
@@ -1,4 +1,5 @@
 ﻿<style>
+    /* Is needed only in V0 as in Shadow DOM V1 we could just not distribute the elements */
     .login-theme-signin__hidden {
         display: none;
     }


### PR DESCRIPTION
For #9 and Starcounter/RebelsLounge#72 .
Related with https://github.com/StarcounterApps/SampleWebsiteTheme/pull/10 .

Other notes:
- Removed the rules that use "::shadow" as they aren't supported anymore and no clear substitute is provided.
- ~~Added rule for "svg" (besides "paper-icon-button") since "svg" is used in SignIn app.~~ The rule should be inside SignIn app and it should use percentage - made a commit in https://github.com/StarcounterApps/SignIn/pull/128 .